### PR TITLE
Removed max users from state to seperate value

### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -6,6 +6,7 @@ import logging
 from homeassistant.helpers.entity import Entity
 ATTR_PING = 'Ping'
 ATTR_USERS = 'Users Online'
+ATTR_MAX = 'Maximum Users'
 ATTR_MOTD = 'MOTD'
 ATTR_VERSION = 'Version'
 ICON = 'mdi:minecraft'
@@ -58,11 +59,12 @@ class MCServerSensor(Entity):
         """Update device state."""
         status = self._mcserver.lookup(self._server).status()
         query = self._mcserver.lookup(self._server).query()
-        self._state = str(status.players.online) + '/' + str(status.players.max)
+        self._state = status.players.online
         self._ping = status.latency
         self._users = query.players.names
         self._motd = query.motd
         self._version = query.software.version
+        self._players_max = status.players.max
 
 
     @property
@@ -71,6 +73,7 @@ class MCServerSensor(Entity):
         return {
        ATTR_PING: self._ping,
        ATTR_USERS: self._users,
+       ATTR_MAX: self._players_max,
        ATTR_MOTD: self._motd,
        ATTR_VERSION: self._version
         }


### PR DESCRIPTION
I ran into some issues trying to setup an automation based on the state, which was two strings separated by a slash, ie 1/10. I think the better solution is to move the maximum number of players to a separate attribute. 

These changes worked for me in Home Assistant  0.99.1 

<img width="492" alt="Screen Shot 2019-09-23 at 5 08 30 PM" src="https://user-images.githubusercontent.com/7231988/65471652-ccf04c80-de24-11e9-9e45-e4b83f4a3f2d.png">

Thanks!